### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,8 @@
 # You can also reference a tag or branch, but the action may change without warning.
 
 name: Push CI Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ventive/go-mono-template/security/code-scanning/10](https://github.com/ventive/go-mono-template/security/code-scanning/10)

To fix the problem, you should add a `permissions` block to the workflow. The most effective way is to add it at the root level, immediately after the `name` and before the `on` key, so that it applies to all jobs unless overridden. The minimal starting point is to set `contents: read`, which restricts the workflow to only read repository contents. If any jobs require additional permissions (such as publishing packages, creating issues, or writing to pull requests), you can add those specific permissions as needed. For this workflow, since it builds and publishes images, you may need to grant `packages: write` for jobs that publish to GHCR, but the minimal fix is to add `contents: read` at the root. This change should be made in `.github/workflows/push.yml` at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
