### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,6 +3,8 @@
 # You can also reference a tag or branch, but the action may change without warning.
 
 name: Pull Request CI pipeline
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ventive/go-mono-template/security/code-scanning/7](https://github.com/ventive/go-mono-template/security/code-scanning/7)

To fix the problem, add a `permissions` block at the top level of the workflow file (just below the `name:` key and before the `on:` key). This will apply the specified permissions to all jobs in the workflow unless overridden at the job level. Since the workflow appears to only need read access (it does not perform any write operations), set `contents: read` as the minimal permission. If any job later requires more permissions, they can be added at the job level. No changes to the jobs themselves are needed unless a job requires additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
