### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Check golang services for vulnerabilities
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/ventive/go-mono-template/security/code-scanning/2](https://github.com/ventive/go-mono-template/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only runs `govulncheck` (a read-only operation on the codebase), it likely only needs `contents: read`. The best practice is to add the `permissions` block at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
